### PR TITLE
Custom content rework

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,14 +26,17 @@ otherwise you're going to have to uninstall and reinstall your entire game if so
 
 # Potential Questions
 
-## HELP, EVERYTHING IS BROKEN
+## HELP, EVERYTHING IS BROKEN AND/OR I REMOVED ALL NON-CUSTOM CONTENT AND CAN'T GET IT BACK
 
 If you're using Steam, go to the Jackbox Party Pack 7 in your Steam Library. Right click on the game's icon or name, click "Properties".
 In the popup window, click on "Local Files". Then click "Verify integrity of game files..." That should fix everything.
 
 ### Important note if you've clicked "verify integrity of game files..."
 
-That means all your custom prompts have been removed from the game. To get your custom prompts back, use the import feature, and select the "custom_content.json" file that's in the same folder as Jackbox Party Pack Custom.exe
+That means all your custom prompts have been removed from the game. To get your custom prompts back, you'll have to follow a couple of steps.
+1. Make a backup of custom_content.json
+2. Use the "Reset All Custom Content" option available in the menu.
+3. Use the import feature, and select the backup you made of custom_content.json.
 
 ## EVERYTHING'S STILL BROKEN
 
@@ -41,7 +44,7 @@ Uninstall and reinstall the Jackbox Party Pack 7
 
 ## NOPE, IT STILL DOESN'T WORK
 
-Delete everything from your Jackbox Party Pack 7 folder, then find the "Verify integrity of game files..." button and click it.
+Delete everything from your Jackbox Party Pack 7/games folder, then find the "Verify integrity of game files..." button and click it.
 
 # Why does this program sometimes use weird names for each game?
 
@@ -56,12 +59,7 @@ The program does this because that's what the folders for each game are called.
 
 # Importing content
 
-As of right now, importing content requires you to manually look at each new piece of content and add it in. I have no idea when I'll change this. Alternatively, you could just copy someone else's Jackbox Party Pack 7 /game/ folder that contains the custom content.
-
-## Note on importing files
-
-The import content feature won't allow you to directly import any custom files, like .OGG files or .JPG files. To do that, you'll need to make a folder of all the custom files
-and then select them in the import dialogs that pop up.
+The import content feature cannot import certain custom files like .JPGs or .OGGs. It'll import things like prompts just fine, but to import things like images and sounds you'll need to go into the editing menu and edit each piece of content that contains a custom file (like a .JPG or .OGG) and add in the image manually.
 
 # Making custom responses to specific text for Quiplash 3:
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,10 @@ otherwise you're going to have to uninstall and reinstall your entire game if so
 
 # Potential Questions
 
+## Doesn't Quiplash 3 already have a way for you to make your own questions?
+
+Yes, but there are a few differences. For one: making your own "episodes" in Quiplash 3 means you have to manually select them. If you add custom questions using this program, they'll get inserted into the normal rotation of questions. For two: using this program will allow you to add more stuff not available in Quiplash 3's "episodes" feature, like audio files to read the questions and custom responses to certain answers. And this program can be used for more games than Quiplash 3.
+
 ## HELP, EVERYTHING IS BROKEN AND/OR I REMOVED ALL NON-CUSTOM CONTENT AND CAN'T GET IT BACK
 
 If you're using Steam, go to the Jackbox Party Pack 7 in your Steam Library. Right click on the game's icon or name, click "Properties".
@@ -46,7 +50,7 @@ Uninstall and reinstall the Jackbox Party Pack 7
 
 Delete everything from your Jackbox Party Pack 7/games folder, then find the "Verify integrity of game files..." button and click it.
 
-# Why does this program sometimes use weird names for each game?
+## Why does this program sometimes use weird names for each game?
 
 I have here a handy conversion for the games and their weird names:
 - BlankyBlank - Blather 'Round

--- a/Readme.md
+++ b/Readme.md
@@ -57,9 +57,17 @@ I have here a handy conversion for the games and their weird names:
 
 The program does this because that's what the folders for each game are called.
 
+# Editing content
+
+If you want to change specific parts of your content or delete content, you're going to want to edit that content in the View/Edit Content option. You should note that you can select multiple pieces of content to edit, view, or delete.
+
 # Importing content
 
 The import content feature cannot import certain custom files like .JPGs or .OGGs. It'll import things like prompts just fine, but to import things like images and sounds you'll need to go into the editing menu and edit each piece of content that contains a custom file (like a .JPG or .OGG) and add in the image manually.
+
+# Using only custom content in a game
+
+This is not at all recommended. If you have less than a certain amount of content for the game to pull from, it might just break entirely. It's better to mix in your custom content with the existing content. If you still want to only use custom content for your game, you can use the "Only Use Custom Content" option from the main menu to delete all existing game content.
 
 # Making custom responses to specific text for Quiplash 3:
 

--- a/jppc.py
+++ b/jppc.py
@@ -168,11 +168,11 @@ class CustomContent(object):
                     file_path = file["path"]
                     name = file["name"]
                     if name == "id":
-                        name = self.id
+                        name = self.id + file["extension"]
                     if file_path == "param_name":
-                        file_path = file["param_name"]
+                        file_path = self.values[file["param_name"]]
                     if(os.path.exists(file_path)): #Only add this if the file's path exists.
-                        copyfile(file_path, path + file['name']) #From shutil
+                        copyfile(file_path, path + "/" + name) #From shutil
                 else: #If we're going to be writing a custom file from like a .JSON or whatever.
                     if isinstance(file, CustomContent):
                         if os.path.exists(path + "data.jet"):
@@ -346,13 +346,17 @@ def game_content_del(game, content_type):
             for content_file in item["args"]:
                 if "path" in content_file:
                     path = content_file["path"]
-                for new_file in os.scandir(path):
-                    file_num = 100000
-                    if new_file.split(".")[0].isnumeric():
-                        file_num = int(new_file.split(".")[0])
-                    if file_num < 100000:
-                        if os.path.exists(path + "/" + new_file):
-                            os.remove(path + "/" + new_file)
+                if os.path.exists(path):
+                    for new_file in os.scandir(path):
+                        file_num = 100000
+                        if new_file.split(".")[0].isnumeric():
+                            file_num = int(new_file.split(".")[0])
+                        file_extension = "/"
+                        if len(new_file.split(".")) > 1:
+                            file_extension = new_file.split(".")[-1]
+                        if file_num < 100000:
+                            if os.path.exists(path + "/" + new_file + file_extension):
+                                os.remove(path + "/" + new_file + file_extension)
                     
 
 
@@ -576,7 +580,7 @@ quiplash_3 = SelectionWindow("Quiplash 3 Content Selection", ["Please select the
 def talking_points_picture_filter(values):
     new_values = values
     if new_values["low_res_path"] == "":
-        new_values["low_res_path"] = new_values["path"]
+        new_values["low_res_path"] = new_values["file_path"]
     new_values["custom_file_path"] = "./JackboxTalks/content/JackboxTalksPicture/"
     return new_values
 
@@ -586,7 +590,7 @@ talking_points_picture = CustomContentWindow("JackboxTalks", "JackboxTalksPictur
         {
             "type": sg.InputText,
             "default_value": "",
-            "param_name": "path"
+            "param_name": "file_path"
         }, {
             "type": sg.FileBrowse,
             "default_value": "Browse",
@@ -625,11 +629,11 @@ talking_points_picture = CustomContentWindow("JackboxTalks", "JackboxTalksPictur
     "content_list": [
         {"type": "json"},
         {"type": "files", "files": {
-            "args": [{"path": "param_name", "param_name": "path", "name": "id"}],
+            "args": [{"path": "param_name", "param_name": "file_path", "name": "id", "extension": ".jpg"}],
             "kwargs": {"path": "./JackboxTalks/content/JackboxTalksPicture", "adding_other_files": True}
         }},
         {"type": "files", "files": {
-            "args": [{"path": "param_name", "param_name": "low_res_path", "name": "id"}],
+            "args": [{"path": "param_name", "param_name": "low_res_path", "name": "id", "extension": ".jpg"}],
             "kwargs": {"path": "./JackboxTalks/content/JackboxTalksPictureLow", "adding_other_files": True}
         }}
     ],

--- a/jppc.py
+++ b/jppc.py
@@ -6,6 +6,7 @@ from shutil import copyfile, rmtree
 #TODO:
 # Test importing content when you already have existing content
 # Test importing content with non-existent custom files (like a .JPG or .OGG)
+# Test Champ'd Up content
 # Edit content by game?
 
 def id_gen(values): #id_gen needs a values dict to work with
@@ -791,9 +792,7 @@ talking_points = SelectionWindow("Talking Points Content Selection", ["Please se
 
 # Champ'd Up Stuff
 
-#TODO: Add file browsing for contest and response .ogg
-
-champd_up_round_1 = CustomContentWindow("WorldChampions", "WorldChampionsRound", "contest", {
+champd_up_round_layout = {
     "previous_window": "champd_up",
     "layout_list": [{"text": "Contest Name: ", "input": [
         {
@@ -807,7 +806,34 @@ champd_up_round_1 = CustomContentWindow("WorldChampions", "WorldChampionsRound",
             "default_value": "<ANYPLAYER>'s Nightmares",
             "param_name": "gameText"
         }
-    ]}, {"input": [
+    ]}, {"text": ".OGG file of you reading the contest name (recommended)", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "",
+            "param_name": "contest_path"
+        }, {
+            "type": sg.FileBrowse,
+            "default_value": "Browse",
+            "param_name": "contest_browse",
+            "kwargs": {
+                "file_types": [(".OGG", "*.ogg"), ("ALL Files", "*.*")]
+            }
+        }
+    ]}, {"text": ".OGG file of you reacting to the prompt (something like 'Oooh! Scary!') (recommended)", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "",
+            "param_name": "response_path"
+        }, {
+            "type": sg.FileBrowse,
+            "default_value": "Browse",
+            "param_name": "response_browse",
+            "kwargs": {
+                "file_types": [(".OGG", "*.ogg"), ("ALL Files", "*.*")]
+            }
+        }
+    ]},
+    {"input": [
         {
             "type": sg.Checkbox,
             "default_value": "Includes Player Name",
@@ -831,15 +857,117 @@ champd_up_round_1 = CustomContentWindow("WorldChampions", "WorldChampionsRound",
     ]}],
     "content_list": [
         {"type": "json"},
-        {"type": "files", "files"}
+        {"type": "CustomData"},
+        {"type": "files", "files": {
+            "args": [{"path": "param_name", "param_name": "contest_path", "name": "contest.ogg"}],
+            "kwargs": {"adding_other_files": True}
+        }}
     ]
+}
+
+champd_up_round_1 = CustomContentWindow("WorldChampions", "WorldChampionsRound", "contest", champd_up_round_layout)
+
+def champd_up_round_import(values):
+    new_values = values
+    new_values["linkedPrompt"] = "|".join(values["linkedPrompts"])
+    return new_values
+
+def champd_up_round_filter(values):
+    new_values = values
+    new_values["linkedPrompts"] = values["linkedPrompts"].split("|")
+    return new_values
+
+champd_up_round_2 = CustomContentWindow("WorldChampions", "WorldChampionsSecondHalfA", "contest", {
+    "previous_window": "champd_up",
+    "layout_list": [{"text": "Contest Name: ", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "The Champion of <ANYPLAYER>",
+            "param_name": "contest"
+        }
+    ]}, {"text": "A shorter description: ", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "<ANYPLAYER>'s Champion",
+            "param_name": "gameText"
+        }
+    ]}, {"text": "List of connected prompts (separate by |): ", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "500000|500002|500120",
+            "param_name": "linkedPrompts"
+        }
+    ]}, {"text": ".OGG file of you reading the contest name (recommended)", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "",
+            "param_name": "contest_path"
+        }, {
+            "type": sg.FileBrowse,
+            "default_value": "Browse",
+            "param_name": "contest_browse",
+            "kwargs": {
+                "file_types": [(".OGG", "*.ogg"), ("ALL Files", "*.*")]
+            }
+        }
+    ]}, {"text": ".OGG file of you reacting to the prompt (something like 'Oooh! Scary!') (recommended)", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "",
+            "param_name": "response_path"
+        }, {
+            "type": sg.FileBrowse,
+            "default_value": "Browse",
+            "param_name": "response_browse",
+            "kwargs": {
+                "file_types": [(".OGG", "*.ogg"), ("ALL Files", "*.*")]
+            }
+        }
+    ]},
+    {"input": [
+        {
+            "type": sg.Checkbox,
+            "default_value": "Includes Player Name",
+            "kwargs": {"default": "existing_data", "regular_default": True},
+            "param_name": "includesPlayerName"
+        }
+    ]}, {"input": [
+        {
+            "type": sg.Checkbox,
+            "default_value": "Includes Adult Content",
+            "kwargs": {"default": "existing_data", "regular_default": False},
+            "param_name": "x"
+        }
+    ]}, {"input": [
+        {
+            "type": sg.Checkbox,
+            "default_value": "Content is US-Specific",
+            "kwargs": {"default": "existing_data", "regular_default": False},
+            "param_name": "us"
+        }
+    ]}],
+    "content_list": [
+        {"type": "json"},
+        {"type": "CustomData"},
+        {"type": "files", "files": {
+            "args": [{"path": "param_name", "param_name": "contest_path", "name": "contest.ogg"}],
+            "kwargs": {"adding_other_files": True}
+        }}
+    ],
+    "filter": champd_up_round_filter,
+    "import_filter": champd_up_round_import
 })
 
+champd_up_round_2_5 = CustomContentWindow("WorldChampions", "WorldChampionsSecondHalfB", "contest", champd_up_round_layout)
+
 champd_up = SelectionWindow("Champ'd Up Content Selection", ["Please select the type of content", ("Round 1 Prompt", "Round 2 Prompt", "Round 2.5 Prompt"), "champd_up_content_type"], {
-    "Round 1 Prompt": champd_up_round_1.create_window
+    "Round 1 Prompt": champd_up_round_1.create_window,
+    "Round 2 Prompt": champd_up_round_2.create_window,
+    "Round 2.5 Prompt": champd_up_round_2_5.create_window
 })
 
 #Main Menu stuff
+
 create_content = SelectionWindow("Select a game", ["Select a game.", ("Champ'd Up", "Quiplash 3", "Talking Points"), "game"],{
     "Blather Round": None,
     "Devils and the Details": None,
@@ -855,6 +983,7 @@ main_window = SelectionWindow("Select an option", ["Please select an option.", (
     "Only Use Custom Content": del_all_else,
     "Reset All Custom Content": all_content_reset
 })
+
 window_mapping = { #Used for backing out of stuff.
     "quiplash_prompt": quiplash_prompt,
     "quiplash_3": quiplash_3,
@@ -863,6 +992,7 @@ window_mapping = { #Used for backing out of stuff.
     "talking_points": talking_points,
     "champd_up": champd_up
 }
+
 content_type_mapping = { #Used in editing content to change data.
     "Quiplash3":{
         "Quiplash3Round1Question": round_prompt_1,
@@ -877,8 +1007,9 @@ content_type_mapping = { #Used in editing content to change data.
     },
     "WorldChampions": {
         "WorldChampionsRound": champd_up_round_1,
-        "WorldChampionsSecondHalfA": "",
-        "WorldChampionsSecondHalfB": ""
+        "WorldChampionsSecondHalfA": champd_up_round_2,
+        "WorldChampionsSecondHalfB": champd_up_round_2_5
     }
 }
+
 main_window.run()

--- a/jppc.py
+++ b/jppc.py
@@ -8,7 +8,7 @@ from shutil import copyfile, rmtree
 # Test feature to delete everything but custom content
 # Test making multiple content of the same type (might not work?)
 # Test importing content when you already have existing content
-# Test importing content with non-existant custom files (like a .JPG or .OGG)
+# Test importing content with non-existent custom files (like a .JPG or .OGG)
 
 def id_gen(values): #id_gen needs a values dict to work with
     ids = None #Start IDs from 100k (to make it distingusihable from other IDs), go from there.
@@ -682,7 +682,7 @@ def talking_points_prompt_filter(values):
             if len(item) > 2 and ("e," in item or "m," in item):
                 position = item[0]
                 signpost = item[2:] #Ignore the m, and e,
-                transitions_list.append({"position": position, "signpost": signpost})
+                transitions_list.append({"position": "end" if position == "e" else "middle", "signpost": signpost})
     new_values["signposts"] = transitions_list
     return new_values
 
@@ -722,6 +722,11 @@ talking_points_prompt = CustomContentWindow("JackboxTalks", "JackboxTalksTitle",
     "filter": talking_points_prompt_filter,
     "import_filter": talking_points_prompt_import
 })
+
+def talking_points_slide_transition_filter(values):
+    new_values = values
+    new_values["position"] = values["position"][0]
+    return new_values
 
 talking_points_slide_transition = CustomContentWindow("JackboxTalks", "JackboxTalksSignpost", "signpost", {
     "previous_window": "talking_points",

--- a/jppc.py
+++ b/jppc.py
@@ -6,7 +6,7 @@ from shutil import copyfile, rmtree
 #TODO:
 # Test if content rework works (plus editing) (Quiplash Prompts Round 1 2 3, Safety Quips, Picture, Slide Transition, Slide Prompt)
 # Test importing content
-# Add feature to delete everything but custom content
+# Test feature to delete everything but custom content
 # Test making multiple content of the same type (might not work?)
 
 def id_gen(values): #id_gen needs a values dict to work with
@@ -322,6 +322,41 @@ def import_content(selected=None):
             main_window.run()
             break
     window.close()
+
+def game_content_del(game, content_type):
+    content = content_type_mapping[game][content_type].window_layout["content_list"]
+    for item in content:
+        content_type = item["type"]
+        path = "./" + game + "/content/" + content_type
+        if content_type == "json":
+            jet_file = open("./" + game + "/content/" + content_type + ".jet", "r", encoding="utf-8")
+            json_file = json.load(json_file)
+            for content_piece in json_file["content"]:
+                if int(content_piece["id"]) < 100000:
+                    json_file["content"].remove(content_piece)
+            jet_file.close()
+            jet_file = open(path + ".jet", "w")
+            jet_file.write(json.dumps(json_file))
+        elif content_type == "CustomData" or content_type == "files":
+            path = path + "/"
+            for item in os.scandir(path + "/"):
+                if int(item) < 100000:
+                    os.remove(path + "/" + item)
+        elif content_type == "files":
+            for content_file in item["args"]:
+                if "path" in content_file:
+                    path = content_file["path"]
+                for new_file in os.scandir(path):
+                    file_num = 100000
+                    if new_file.split(".")[0].isnumeric():
+                        file_num = int(new_file.split(".")[0])
+                    if file_num < 100000:
+                        if os.path.exists(path + "/" + new_file):
+                            os.remove(path + "/" + new_file)
+                    
+
+
+
 
 def del_all_else(selected=None):
     layout = [[sg.Text("Are you absolutely sure you want to do this?")], [sg.Text("This option will effectively delete all the game's content files so that you can only play with your own custom content. Please make sure you have backups.")],

--- a/jppc.py
+++ b/jppc.py
@@ -791,13 +791,61 @@ talking_points = SelectionWindow("Talking Points Content Selection", ["Please se
 
 # Champ'd Up Stuff
 
+#TODO: Add file browsing for contest and response .ogg
+
+champd_up_round_1 = CustomContentWindow("WorldChampions", "WorldChampionsRound", "contest", {
+    "previous_window": "champd_up",
+    "layout_list": [{"text": "Contest Name: ", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "The Champion of <ANYPLAYER>'s Nightmares",
+            "param_name": "contest"
+        }
+    ]}, {"text": "A shorter description: ", "input": [
+        {
+            "type": sg.InputText,
+            "default_value": "<ANYPLAYER>'s Nightmares",
+            "param_name": "gameText"
+        }
+    ]}, {"input": [
+        {
+            "type": sg.Checkbox,
+            "default_value": "Includes Player Name",
+            "kwargs": {"default": "existing_data", "regular_default": True},
+            "param_name": "includesPlayerName"
+        }
+    ]}, {"input": [
+        {
+            "type": sg.Checkbox,
+            "default_value": "Includes Adult Content",
+            "kwargs": {"default": "existing_data", "regular_default": False},
+            "param_name": "x"
+        }
+    ]}, {"input": [
+        {
+            "type": sg.Checkbox,
+            "default_value": "Content is US-Specific",
+            "kwargs": {"default": "existing_data", "regular_default": False},
+            "param_name": "us"
+        }
+    ]}],
+    "content_list": [
+        {"type": "json"},
+        {"type": "files", "files"}
+    ]
+})
+
+champd_up = SelectionWindow("Champ'd Up Content Selection", ["Please select the type of content", ("Round 1 Prompt", "Round 2 Prompt", "Round 2.5 Prompt"), "champd_up_content_type"], {
+    "Round 1 Prompt": champd_up_round_1.create_window
+})
+
 #Main Menu stuff
-create_content = SelectionWindow("Select a game", ["Select a game.", ("Talking Points", "Quiplash 3"), "game"],{
+create_content = SelectionWindow("Select a game", ["Select a game.", ("Champ'd Up", "Quiplash 3", "Talking Points"), "game"],{
     "Blather Round": None,
     "Devils and the Details": None,
     "Talking Points": talking_points.run,
     "Quiplash 3": quiplash_3.run,
-    "Champ'd Up": None
+    "Champ'd Up": champd_up.run
 }, "main_window")
 
 main_window = SelectionWindow("Select an option", ["Please select an option.", ("Create Custom Content", "View/Edit Content", "Import Content", "Only Use Custom Content", "Reset All Custom Content"), "option"], {
@@ -812,7 +860,8 @@ window_mapping = { #Used for backing out of stuff.
     "quiplash_3": quiplash_3,
     "create_content": create_content,
     "main_window": main_window,
-    "talking_points": talking_points
+    "talking_points": talking_points,
+    "champd_up": champd_up
 }
 content_type_mapping = { #Used in editing content to change data.
     "Quiplash3":{
@@ -825,6 +874,11 @@ content_type_mapping = { #Used in editing content to change data.
         "JackboxTalksPicture": talking_points_picture,
         "JackboxTalksTitle": talking_points_prompt,
         "JackboxTalksSignpost": talking_points_slide_transition
+    },
+    "WorldChampions": {
+        "WorldChampionsRound": champd_up_round_1,
+        "WorldChampionsSecondHalfA": "",
+        "WorldChampionsSecondHalfB": ""
     }
 }
 main_window.run()

--- a/jppc.py
+++ b/jppc.py
@@ -42,7 +42,7 @@ class CustomContent(object):
         self.window_layout = args[3]
         if "id" in kwargs:
             self.id = kwargs["id"]
-    
+
     def write_to_json(self, p=None, delete=False): #Right now, add_custom_files doesn't support custom file paths. Only write_to_json supports custom paths for data.jet files.
         path = "" 
         if p:
@@ -90,7 +90,7 @@ class CustomContent(object):
             path = kwargs["path"]
         else:
             path = "./" + self.values["game"] + "/content/" + self.values["content_type"] + "/" + self.id + "/"
-        if os.path.exists(path) and "edit" in kwargs and kwargs["edit"] == True: #If there's a folder here, but we're not selecting a custom path
+        if os.path.exists(path) and not ("path" in kwargs and ("keep_dir" in kwargs and kwargs["keep_dir"] == True)): #If there's a folder here, but we're not selecting a custom path
             rmtree(path)
         if not ("delete" in kwargs and kwargs["delete"] == True):
             if not (os.path.exists(path)):
@@ -304,7 +304,7 @@ def create_quiplash_data_jet(values):
     data.add_data("S", values["response_transcript"], "KeywordResponseText")
     data.add_data("B", "true" if values["prompt"] != "" else "false", "HasPromptAudio")
     data.add_data("A", "prompt", "PromptAudio") #I think this is asking for the file name of the audio. I think I can leave this in if the audio doesn't exist, because some prompts don't have response audio, but we include the above line. 
-    data.add_data("S", values["prompt"], "Prompt Text")
+    data.add_data("S", values["prompt"], "PromptText")
     data.add_data("S", "|".join(values["safetyQuips"]), "SafetyQuips")
     return data
 
@@ -385,7 +385,7 @@ def round_prompt(selected, existing_data=None):
             {"type": "CustomData", "func": create_quiplash_data_jet, "kwargs": {}},
             {"type": "files", "files": {
                 "args": [{"path": "param_name", "param_name": "prompt_file_browse", "name": "prompt.ogg"}, {"path": "param_name", "param_name": "response_file_browse", "name": "response.ogg"}],
-                "kwargs": {}
+                "kwargs": {"keep_dir": True}
             }}
         ],
         "filter": round_filter

--- a/jppc.py
+++ b/jppc.py
@@ -4,6 +4,7 @@ import os
 from shutil import copyfile, rmtree
 
 #TODO:
+# Rework game specific content to be more object oriented.
 # Test safety quips
 # Test importing content
 # Test Talking Points Slide transitions
@@ -35,13 +36,13 @@ def id_gen(custom_values): #custom_values should be a dict that passes on any ot
     return _id
 
 class CustomContent(object):
-    def __init__(self, values, game, content_type, descriptor_text, _id=None): #values, game, content_type, descriptor_text, _id=None
-        self.values = {"game": game, "content_type": content_type, "descriptor_text": descriptor_text}
-        self.values.update(values)
-        if _id == None: #Are we using an existing id?
+    def __init__(self, *args, **kwargs): #values, game, content_type, descriptor_text, _id=None
+        self.values = {"game": args[1], "content_type": args[2], "descriptor_text": args[3]}
+        self.values.update(args[0])
+        if not "id" in kwargs: #Are we using an existing id?
             self.id = id_gen(self.values)
         else:
-            self.id = _id
+            self.id = kwargs["id"]
         self.values.update({"id": self.id})
     
     def write_to_json(self, p=None, delete=False): #Right now, add_custom_files doesn't support custom file paths. Only write_to_json supports custom paths for data.jet files.
@@ -103,6 +104,10 @@ class CustomContent(object):
                         f = open(path + file['name'], "w+")
                         f.write(file['str'])
                         f.close()
+
+    def create_window(self, existing_data=None):
+        layout = []
+        window = sg.Window("" if existing_data == None else existing_data["id"])
 
 class CustomData(CustomContent):
     def __init__(self):

--- a/jppc.py
+++ b/jppc.py
@@ -4,12 +4,9 @@ import os
 from shutil import copyfile, rmtree
 
 #TODO:
-# Test if content rework works (plus editing) (Quiplash Prompts Round 1 2 3, Safety Quips)
-# Test feature to delete everything but custom content (Works with Talking Points)
-# Test making multiple content of the same type (might not work?)
 # Test importing content when you already have existing content
 # Test importing content with non-existent custom files (like a .JPG or .OGG)
-# Test editing with multiple content
+# Edit content by game?
 
 def id_gen(values): #id_gen needs a values dict to work with
     ids = None #Start IDs from 100k (to make it distingusihable from other IDs), go from there.
@@ -524,12 +521,17 @@ def round_final_filter(values):
     new_values = values
     formatted_quips = []
     safety_quip = new_values["safetyQuips"].split("|")
-    for i in range(len(safety_quip)):
+    for i in range(0, len(safety_quip), 3):
         if not (i + 3 > len(safety_quip)):
-            formatted_quips.append(safety_quip[i][0] + "|" + safety_quip[i][1] + "|" + safety_quip[i][2])
+            formatted_quips.append(safety_quip[i] + "|" + safety_quip[i + 1] + "|" + safety_quip[i + 2])
     new_values["safetyQuips"] = formatted_quips
     new_values["response_filter"] = ""
     new_values["response_transcript"] = ""
+    return new_values
+
+def round_final_import(values):
+    new_values = values
+    new_values["safetyQuips"] = "|".join(values["safetyQuips"])
     return new_values
 
 round_prompt_final = CustomContentWindow("Quiplash3", "Quiplash3FinalQuestion", "prompt", {
@@ -585,7 +587,8 @@ round_prompt_final = CustomContentWindow("Quiplash3", "Quiplash3FinalQuestion", 
             "kwargs": {"adding_other_files": True}
         }}
     ],
-    "filter": round_final_filter
+    "filter": round_final_filter,
+    "import_filter": round_final_import
 })
 
 safety_quip = CustomContentWindow("Quiplash3", "Quiplash3SafetyQuips", "value", {
@@ -785,6 +788,8 @@ talking_points = SelectionWindow("Talking Points Content Selection", ["Please se
     "Prompt": talking_points_prompt.create_window,
     "Slide Transition": talking_points_slide_transition.create_window
 }, "create_content")
+
+# Champ'd Up Stuff
 
 #Main Menu stuff
 create_content = SelectionWindow("Select a game", ["Select a game.", ("Talking Points", "Quiplash 3"), "game"],{

--- a/jppc.py
+++ b/jppc.py
@@ -8,6 +8,8 @@ from shutil import copyfile, rmtree
 # Test importing content
 # Add example images in the Readme
 # Add feature to delete everything but custom content
+# Fix the import feature so it just automatically adds everything.
+# Test making multiple content of the same type (might not work?)
 
 def id_gen(custom_values): #custom_values should be a dict that passes on any other identifying information for the user
     ids = None #Start IDs from 100k (to make it distingusihable from other IDs), go from there.
@@ -236,10 +238,10 @@ def edit_content(selected=None): #Selected goes unused because of how SelectWind
             if event == "Edit":
                 _id = values["content_selection"][0].split(":")[0]
                 existing_data = content[_id]["values"]
-                content_type_mapping[existing_data["content_type"]](existing_data=existing_data)
+                content_type_mapping[existing_data["content_type"]].create_window(existing_data=existing_data)
             if event == "Delete":
                 _id = values["content_selection"][0].split(":")[0]
-                custom_content = CustomContent(content[_id]["values"], content[_id]["values"]["game"], content[_id]["values"]["content_type"], content[_id]["values"]["descriptor_text"], _id) #Setting None because values already has the game, type, and descriptor_text.
+                custom_content = CustomContent(content[_id]["values"]["game"], content[_id]["values"]["content_type"], content[_id]["values"]["content_type"], content[_id]["values"]["descriptor_text"], _id) #Setting None because values already has the game, type, and descriptor_text.
                 #Remove the content from the custom_content JSON file
                 content.pop(_id)
                 #Remove the content from the game's master .JET file
@@ -287,7 +289,7 @@ def import_content(selected=None):
                     for i in range(new_content.keys()):
                         n_c = new_content[new_content.keys(i)]
                         content[str(latest_id + i + 1)] = n_c
-                        content_type_mapping[n_c["content_type"]](existing_data=n_c["values"]) #Requires you to manually add in each piece of content.
+                        content_type_mapping[n_c["content_type"]].create_window(existing_data=n_c["values"]) #Requires you to manually add in each piece of content.
                     ids.seek(0)
                     ids.truncate()
                     ids.write(json.dumps(content))
@@ -415,8 +417,10 @@ def round_final_filter(values):
     safety_quip = new_values["safetyQuips"].split("|")
     for i in range(len(safety_quip)):
         if not (i + 3 > len(safety_quip)):
-            formatted_quips.append(safety_quip[0] + "|" + safety_quip[1] + "|" + safety_quip[2])
+            formatted_quips.append(safety_quip[i][0] + "|" + safety_quip[i][1] + "|" + safety_quip[i][2])
     new_values["safetyQuips"] = formatted_quips
+    new_values["response_filter"] = ""
+    new_values["response_transcript"] = ""
     return new_values
 
 round_prompt_final = CustomContent("Quiplash3", "Quiplash3FinalQuestion", "prompt", {
@@ -680,12 +684,12 @@ window_mapping = { #Used for backing out of stuff.
     "talking_points": talking_points
 }
 content_type_mapping = { #Used in editing content to change data.
-    "Quiplash3Round1Question": round_prompt_1.create_window,
-    "Quiplash3Round2Question": round_prompt_2.create_window,
-    "Quiplash3FinalQuestion": round_prompt_final.create_window,
-    "Quiplash3SafetyQuips": safety_quip.create_window,
-    "JackboxTalksPicture": talking_points_picture.create_window,
-    "JackboxTalksTitle": talking_points_prompt.create_window,
-    "JackboxTalksSignpost": talking_points_slide_transition.create_window
+    "Quiplash3Round1Question": round_prompt_1,
+    "Quiplash3Round2Question": round_prompt_2,
+    "Quiplash3FinalQuestion": round_prompt_final,
+    "Quiplash3SafetyQuips": safety_quip,
+    "JackboxTalksPicture": talking_points_picture,
+    "JackboxTalksTitle": talking_points_prompt,
+    "JackboxTalksSignpost": talking_points_slide_transition
 }
 main_window.run()

--- a/jppc.py
+++ b/jppc.py
@@ -56,7 +56,8 @@ class CustomContentWindow(object):
                 data = content["func"](new_content.values)
                 kwargs = content["kwargs"]
                 new_content.add_custom_files(data, **kwargs)
-        sg.Popup("Content Created, ID: " + new_content.id)
+        if not ("window_suppress" in kwargs and kwargs["window_suppress"] == True):
+            sg.Popup("Content Created, ID: " + new_content.id)
 
     def create_window(self, *args, **kwargs):
         existing_data = None
@@ -325,7 +326,7 @@ def import_content(selected=None):
                     content[content_id] = n_c
                     n_c["id"] = content_id
                     n_c["values"]["id"] = content_id
-                    content_type_mapping[n_c["values"]["game"]][n_c["values"]["content_type"]].create_content(n_c["values"], content_id) #Will bug you with popups rn.
+                    content_type_mapping[n_c["values"]["game"]][n_c["values"]["content_type"]].create_content(n_c["values"], content_id, window_suppress=True) #Will bug you with popups rn.
                 ids.seek(0)
                 ids.truncate()
                 ids.write(json.dumps(content))


### PR DESCRIPTION
Added a ton of new things:
- For one, the content system got a rework. Instead of manually adding new windows for each piece of content, it iterates over a window layout dictionary to make each piece of content. Just easier for me to work with and develop for.
- I've added Champ'd Up content, which allows connected prompts and audio files.
- Improvements to editing and importing content:
  - You can now select multiple files to edit and delete
  - You no longer have to manually go over each piece of imported content (although I haven't tested importing with custom files that don't exist)
  - Importing should work with existing content now.
- Added a feature that allows you to only use custom content for specific games.
- Sorted content_type_mapping by game
- Added a feature to reset your custom content if you've restored your game files to their original condition.